### PR TITLE
upgraded to Python3 runtime + legacy bundled services

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,20 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Python pycache:
+__pycache__/
+# Ignored by the build system
+/setup.cfg
+

--- a/app.yaml
+++ b/app.yaml
@@ -1,10 +1,5 @@
-api_version: 1
-runtime: python27
-threadsafe: true
-
-libraries:
-- name: ssl
-  version: latest
+runtime: python312
+app_engine_apis: true
 
 handlers:
 - url: /static

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,5 +1,0 @@
-"""Add the lib directory to the path, so you can use libraries."""
-
-import sys
-import os.path
-sys.path.append(os.path.join(os.path.dirname(__file__), 'lib'))

--- a/main.py
+++ b/main.py
@@ -6,12 +6,13 @@ from flask import Flask
 from flask import request
 from flask import make_response
 
-from google.appengine.ext import blobstore
-from google.appengine.api import images
+from google.appengine.api import images, wrap_wsgi_app
 
 JSON_MIME_TYPE = 'application/json'
 
 app = Flask(__name__)
+app.wsgi_app = wrap_wsgi_app(app.wsgi_app)
+
 
 @app.route('/image-url', methods=['GET'])
 def image_url():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.0.2
-Werkzeug==0.14.1
-google-api-python-client==1.7.7
-GoogleAppEngineCloudStorageClient==1.9.22.1
+appengine-python-standard==1.1.6
+Flask==3.0.3
+google-api-python-client==2.129.0
+google-cloud-storage==2.16.0


### PR DESCRIPTION
The App Engine standard environment has two generations of [runtime environments](https://cloud.google.com/appengine/docs/standard/runtimes), first and second.
This PR upgrades python-gcs-image from Python 2 (first generation runtime) to Python 3 (second generation runtime).


## References

Support for legacy runtimes
https://cloud.google.com/appengine/docs/standard/long-term-support

**Images API for legacy bundled services**
https://cloud.google.com/appengine/docs/legacy/standard/python/images

> Note: Python 2.7 has reached end of support on January 31, 2024. Your existing Python 2.7 applications will continue to run and receive traffic. However, App Engine might block re-deployment of applications that use runtimes after their end of support date. We recommend that you migrate to the latest supported version of Python. 

**Migrate to the Python 3 runtime**
https://cloud.google.com/appengine/migration-center/standard/migrate-to-second-gen/python-differences#configuration

🌟 **Access legacy bundled services for Python 3** (very important and useful link)
https://cloud.google.com/appengine/docs/standard/python3/services/access

🌟 **Google Cloud Tech - Extending support for App Engine bundled services: Part 1 (Module 17)** (very important and useful link)
https://www.youtube.com/watch?v=Tyyv4_Khyk0

**Runtime support schedule #Python**
https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#python

**Python 3 Runtime Environment**
https://cloud.google.com/appengine/docs/standard/python3/runtime

**Resize Images on Google Cloud Storage** (original blog post for [python-gcs-image](https://github.com/albertcht/python-gcs-image) project)
https://blog.albert-chen.com/resize-images-on-google-cloud-storage/

## Upgrade path:

---

add:
```
appengine-python-standard
```
to `requirements.txt`

https://youtu.be/Tyyv4_Khyk0?t=242

---

Changes in `app.yaml`:

- update `runtime` entry.
- remove `threadsafe`
- remove `api_version`
- remove `libraries` sections since it is not supported anymore and all the extra packages goes into `requirements.txt` file.
- add `app_engine_apis`

https://youtu.be/Tyyv4_Khyk0?t=255

---

remove the following files and directories:
```
appengine_config.py
lib/
```
`lib` folder is removed and all the extra packages goes into `requirements.txt` file.

https://youtu.be/Tyyv4_Khyk0?t=306
https://youtu.be/Tyyv4_Khyk0?t=381

---

use `wrap_wsgi_app` ain `main.py`.
https://youtu.be/Tyyv4_Khyk0?t=342

---

deploy only with:
```bash
gcloud app deploy
```

and don't use the following, since `lib` directory is now removed.

```bash
pip install -t lib -r requirements.txt
```

## Deployment to bengurion-dev

https://bengurion-dev.ew.r.appspot.com/image-url?bucket=bengurion-local-testing&image=series/10/images/nutricia_example_1.jpg

```
$ gcloud app deploy 
Services to deploy:

descriptor:                  [~/projects/python-gcs-image/app.yaml]
source:                      [~/projects/python-gcs-image]
target project:              [bengurion-dev]
target service:              [default]
target version:              [20240523t150447]
target url:                  [https://bengurion-dev.ew.r.appspot.com]
target service account:      [bengurion-dev@appspot.gserviceaccount.com]


Do you want to continue (Y/n)?  y
```


## Service

By default, this is deployed to `default` service. Instead of that, to deploy to a service named `python3-gcs-image`, add the following line into `app.yaml`:

```yaml
service: python3-gcs-image
```


## Resolved Issues

If `gcloud app deploy` command raises the following error:

```
ERROR: (gcloud.app.deploy) B instance [staging.bengurion-dev.appspot.com] not found:
The specified bucket does not exist.
```

Then, the following command fixes it:

```bash
gcloud beta app repair
```

https://cloud.google.com/sdk/gcloud/reference/beta/app/repair

https://stackoverflow.com/questions/76826568/gcloud-app-deploy-complains-about-missing-staging-bucket

Also, Cloud Shell raised a permissions error while it worked in local computer.


## Also See

- https://github.com/lab4motion/bms-kubernetes/pull/733
